### PR TITLE
Fix unable to get reviewrateble item from rating model

### DIFF
--- a/src/Models/Rating.php
+++ b/src/Models/Rating.php
@@ -21,7 +21,7 @@ class Rating extends Model
      */
     public function reviewrateable()
     {
-        return $this->morphTo();
+        return $this->morphTo(__FUNCTION__, 'reviewable_type', 'reviewable_id');
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where `$rating->reviewrateable` returned null. It should return the related model.