### PR TITLE
fix: resolve PHP 8.4 implicitly nullable param deprecations

### DIFF
--- a/src/Contracts/ReviewRateableContract.php
+++ b/src/Contracts/ReviewRateableContract.php
@@ -26,33 +26,33 @@ interface ReviewRateableContract
     /**
      * Update a review by its ID.
      *
-     * @param int   $reviewId
-     * @param array $data
+     * @param  int|null   $reviewId
+     * @param  array|null $data
      * @return bool
      */
-    public function updateReview(int $reviewId = null, array $data = null): bool;
+    public function updateReview(?int $reviewId = null, ?array $data = null): bool;
 
     /**
      * Mark a review as approved by its ID.
      *
-     * @param int $reviewId
+     * @param  int|null $reviewId
      * @return bool
      */
-    public function approveReview(int $reviewId = null): bool;
+    public function approveReview(?int $reviewId = null): bool;
 
     /**
      * Get the average rating for a given key.
      *
-     * @param string $key
-     * @param bool $approved
+     * @param  string|null $key
+     * @param  bool        $approved
      * @return float|null
      */
-    public function averageRating(string $key = null, bool $approved = true): ?float;
+    public function averageRating(?string $key = null, bool $approved = true): ?float;
 
     /**
      * Get overall average ratings for all keys.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return array
      */
     public function averageRatings(bool $approved = true): array;
@@ -60,18 +60,22 @@ interface ReviewRateableContract
     /**
      * Get the average rating for a given key within a department.
      *
-     * @param string $department
-     * @param string $key
-     * @param bool $approved
+     * @param  string      $department
+     * @param  string|null $key
+     * @param  bool        $approved
      * @return float|null
      */
-    public function averageRatingByDepartment(string $department = "default", string $key = null, bool $approved = true): ?float;
+    public function averageRatingByDepartment(
+        string $department = "default",
+        ?string $key = null,
+        bool $approved = true
+    ): ?float;
 
     /**
      * Get overall average ratings for all keys within a department.
      *
-     * @param string $department
-     * @param bool $approved
+     * @param  string $department
+     * @param  bool   $approved
      * @return array
      */
     public function averageRatingsByDepartment(string $department = "default", bool $approved = true): array;
@@ -79,8 +83,8 @@ interface ReviewRateableContract
     /**
      * Get all reviews (with attached ratings) for the attached model.
      *
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  bool $approved
+     * @param  bool $withRatings
      * @return Collection
      */
     public function getReviews(bool $approved = true, bool $withRatings = true): Collection;
@@ -89,17 +93,21 @@ interface ReviewRateableContract
      * Get all reviews (with attached ratings) for a department,
      * filtered by the approved status.
      *
-     * @param string $department
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  string $department
+     * @param  bool   $approved
+     * @param  bool   $withRatings
      * @return Collection
      */
-    public function getReviewsByDepartment(string $department = "default", bool $approved = true, bool $withRatings = true): Collection;
+    public function getReviewsByDepartment(
+        string $department = "default",
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection;
 
     /**
      * Get the total number of reviews for the attached model.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return int
      */
     public function totalReviews(bool $approved = true): int;
@@ -107,8 +115,8 @@ interface ReviewRateableContract
     /**
      * Get the total number of reviews for the model by department.
      *
-     * @param string $department
-     * @param bool $approved
+     * @param  string $department
+     * @param  bool   $approved
      * @return int
      */
     public function totalDepartmentReviews(string $department = "default", bool $approved = true): int;
@@ -116,7 +124,7 @@ interface ReviewRateableContract
     /**
      * Get the overall average rating for all ratings attached to the model.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return float|null
      */
     public function overallAverageRating(bool $approved = true): ?float;
@@ -124,17 +132,17 @@ interface ReviewRateableContract
     /**
      * Delete a review.
      *
-     * @param int $reviewId
+     * @param  int|null $reviewId
      * @return bool
      */
-    public function deleteReview(int $reviewId = null): bool;
+    public function deleteReview(?int $reviewId = null): bool;
 
     /**
      * Return an array of rating value ⇒ count, for the full model
      * or for a given department.
      *
-     * @param string|null $department
-     * @param bool $approved
+     * @param  string|null $department
+     * @param  bool        $approved
      * @return array
      */
     public function ratingCounts(?string $department = "default", bool $approved = true): array;
@@ -145,8 +153,8 @@ interface ReviewRateableContract
      *  • percentages: [1 => pct1, …, 5 => pct5]
      *  • total:      total number of ratings
      *
-     * @param  string|null  $department
-     * @param  bool         $approved
+     * @param  string|null $department
+     * @param  bool        $approved
      * @return array
      */
     public function ratingStats(?string $department = "default", bool $approved = true): array;
@@ -154,11 +162,16 @@ interface ReviewRateableContract
     /**
      * Return reviews based on star ratings.
      *
-     * @param int|null $starValue
-     * @param string $department
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  int|null    $starValue
+     * @param  string      $department
+     * @param  bool        $approved
+     * @param  bool        $withRatings
      * @return Collection
      */
-    public function getReviewsByRating(int $starValue = null, string $department = "default", bool $approved   = true, bool $withRatings = true): Collection;
+    public function getReviewsByRating(
+        ?int $starValue = null,
+        string $department = "default",
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection;
 }

--- a/src/Services/ReviewRateableService.php
+++ b/src/Services/ReviewRateableService.php
@@ -11,17 +11,18 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * The reviewable model instance.
      */
-    protected mixed $model;
+    protected mixed $model = null;
 
     /**
      * Set the model instance to operate on.
      *
-     * @param mixed $model
+     * @param  mixed $model
      * @return self
      */
     public function setModel(mixed $model): self
     {
         $this->model = $model;
+
         return $this;
     }
 
@@ -33,21 +34,22 @@ class ReviewRateableService implements ReviewRateableContract
      */
     protected function getModel(): mixed
     {
-        if (!$this->model) {
+        if ($this->model === null) {
             throw new Exception("No model set in ReviewRateableService. Please call setModel() first.");
         }
+
         return $this->model;
     }
 
     /**
      * Delegate adding a review to the model.
      *
-     * @param array $data
-     * @param int|null $userId
+     * @param  array     $data
+     * @param  int|null  $userId
      * @return ReviewRateableContract
      * @throws Exception
      */
-    public function addReview(array $data, ?int $userId = null): ReviewRateableContract
+    public function addReview(array $data, ?int $userId = null): mixed
     {
         return $this->getModel()->addReview($data, $userId);
     }
@@ -55,27 +57,24 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Update a review and its ratings by review ID.
      *
-     * The $data array can include:
-     *  - 'review': New review text.
-     *  - 'department': New department key.
-     *  - 'recommend': New recommendation flag.
-     *  - 'approved': New approval status.
-     *  - 'ratings': An associative array of rating values (key => value).
-     *
-     * @param int $reviewId
-     * @param array $data
+     * @param  int|null   $reviewId
+     * @param  array|null $data
      * @return bool  True on success, false if the review was not found.
      * @throws Exception
      */
-    public function updateReview(int $reviewId = null, array $data = null): bool
+    public function updateReview(?int $reviewId = null, ?array $data = null): bool
     {
         return $this->getModel()->updateReview($reviewId, $data);
     }
 
     /**
      * Delegate approving a review.
+     *
+     * @param  int|null $reviewId
+     * @return bool
+     * @throws Exception
      */
-    public function approveReview(int $reviewId = null): bool
+    public function approveReview(?int $reviewId = null): bool
     {
         return $this->getModel()->approveReview($reviewId);
     }
@@ -83,12 +82,12 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Delegate averageRating calculation to the model.
      *
-     * @param string $key
-     * @param bool $approved
+     * @param  string|null $key
+     * @param  bool        $approved
      * @return float|null
      * @throws Exception
      */
-    public function averageRating(string $key = null, bool $approved = true): ?float
+    public function averageRating(?string $key = null, bool $approved = true): ?float
     {
         return $this->getModel()->averageRating($key, $approved);
     }
@@ -96,7 +95,7 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Delegate averageRatings calculation to the model.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return array
      * @throws Exception
      */
@@ -108,22 +107,25 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Delegate averageRatingByDepartment calculation to the model.
      *
-     * @param string $department
-     * @param string $key
-     * @param bool $approved
+     * @param  string      $department
+     * @param  string|null $key
+     * @param  bool        $approved
      * @return float|null
      * @throws Exception
      */
-    public function averageRatingByDepartment(string $department = "default", string $key = null, bool $approved = true): ?float
-    {
+    public function averageRatingByDepartment(
+        string $department = "default",
+        ?string $key = null,
+        bool $approved = true
+    ): ?float {
         return $this->getModel()->averageRatingByDepartment($department, $key, $approved);
     }
 
     /**
      * Delegate averageRatingsByDepartment calculation to the model.
      *
-     * @param string $department
-     * @param bool $approved
+     * @param  string $department
+     * @param  bool   $approved
      * @return array
      * @throws Exception
      */
@@ -135,8 +137,8 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Get all reviews (with attached ratings) for the attached model.
      *
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  bool $approved
+     * @param  bool $withRatings
      * @return Collection
      * @throws Exception
      */
@@ -149,21 +151,24 @@ class ReviewRateableService implements ReviewRateableContract
      * Get all reviews (with attached ratings) for a department,
      * filtered by the approved status.
      *
-     * @param string $department
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  string $department
+     * @param  bool   $approved
+     * @param  bool   $withRatings
      * @return Collection
      * @throws Exception
      */
-    public function getReviewsByDepartment(string $department = "default", bool $approved = true, bool $withRatings = true): Collection
-    {
+    public function getReviewsByDepartment(
+        string $department = "default",
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection {
         return $this->getModel()->getReviewsByDepartment($department, $approved, $withRatings);
     }
 
     /**
      * Get the total number of ratings for the attached model.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return int
      * @throws Exception
      */
@@ -175,8 +180,8 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Get the total number of reviews for the model by department.
      *
-     * @param string $department
-     * @param bool $approved
+     * @param  string $department
+     * @param  bool   $approved
      * @return int
      * @throws Exception
      */
@@ -188,7 +193,7 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Get the overall average rating for all ratings attached to the model.
      *
-     * @param bool $approved
+     * @param  bool $approved
      * @return float|null
      * @throws Exception
      */
@@ -198,11 +203,13 @@ class ReviewRateableService implements ReviewRateableContract
     }
 
     /**
-     * @param int $reviewId
+     * Delete a review.
+     *
+     * @param  int|null $reviewId
      * @return bool
      * @throws Exception
      */
-    public function deleteReview(int $reviewId = null): bool
+    public function deleteReview(?int $reviewId = null): bool
     {
         return $this->getModel()->deleteReview($reviewId);
     }
@@ -211,8 +218,8 @@ class ReviewRateableService implements ReviewRateableContract
      * Return an array of rating value ⇒ count, for the full model
      * or for a given department.
      *
-     * @param string|null $department
-     * @param bool $approved
+     * @param  string|null $department
+     * @param  bool        $approved
      * @return array
      * @throws Exception
      */
@@ -227,8 +234,8 @@ class ReviewRateableService implements ReviewRateableContract
      *  • percentages: [1 => pct1, …, 5 => pct5]
      *  • total:      total number of ratings
      *
-     * @param string|null $department
-     * @param bool $approved
+     * @param  string|null $department
+     * @param  bool        $approved
      * @return array
      * @throws Exception
      */
@@ -240,15 +247,19 @@ class ReviewRateableService implements ReviewRateableContract
     /**
      * Return reviews based on star ratings.
      *
-     * @param int $starValue
-     * @param string|null $department
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param  int|null    $starValue
+     * @param  string      $department
+     * @param  bool        $approved
+     * @param  bool        $withRatings
      * @return Collection
      * @throws Exception
      */
-    public function getReviewsByRating(int $starValue = null, string $department = "default", bool $approved = true, bool $withRatings = true): Collection
-    {
+    public function getReviewsByRating(
+        ?int $starValue = null,
+        string $department = "default",
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection {
         return $this->getModel()->getReviewsByRating($starValue, $department, $approved, $withRatings);
     }
 }

--- a/src/Traits/ReviewRateable.php
+++ b/src/Traits/ReviewRateable.php
@@ -5,7 +5,7 @@ namespace Codebyray\ReviewRateable\Traits;
 use Codebyray\ReviewRateable\Models\Rating;
 use Codebyray\ReviewRateable\Models\Review;
 use Illuminate\Database\Eloquent\Collection;
-use DB;
+use Illuminate\Support\Facades\DB;
 
 trait ReviewRateable
 {
@@ -28,7 +28,7 @@ trait ReviewRateable
      *  - 'ratings': An associative array of rating values.
      *
      * @param  array      $data
-     * @param int|null $userId
+     * @param  int|null   $userId
      * @return Review
      */
     public function addReview(array $data, ?int $userId = null): Review
@@ -50,7 +50,7 @@ trait ReviewRateable
         );
 
         // Get allowed rating keys for the specified department.
-        $departments = config('review-rateable.departments', []);
+        $departments   = config('review-rateable.departments', []);
         $configRatings = $departments[$department]['ratings'] ?? [];
 
         // Get global min and max rating values.
@@ -91,12 +91,16 @@ trait ReviewRateable
      *  - 'approved': New approval status.
      *  - 'ratings': An associative array of rating values (key => value).
      *
-     * @param int   $reviewId
-     * @param array $data
-     * @return bool  True on success, false if the review was not found.
+     * @param int|null   $reviewId
+     * @param array|null $data
+     * @return bool  True on success, false if the review was not found or invalid input.
      */
-    public function updateReview(int $reviewId = null, array $data = null): bool
+    public function updateReview(?int $reviewId = null, ?array $data = null): bool
     {
+        if ($reviewId === null || $data === null) {
+            return false;
+        }
+
         $review = $this->reviews()->find($reviewId);
 
         if (!$review) {
@@ -124,8 +128,8 @@ trait ReviewRateable
         // Update ratings if provided.
         if (isset($data['ratings']) && is_array($data['ratings'])) {
             // Determine which department's rating keys to use.
-            $department = $attributes['department'] ?? $review->department;
-            $departments = config('review-rateable.departments', []);
+            $department    = $attributes['department'] ?? $review->department;
+            $departments   = config('review-rateable.departments', []);
             $configRatings = $departments[$department]['ratings'] ?? [];
 
             // Get global min and max rating values.
@@ -156,32 +160,39 @@ trait ReviewRateable
     /**
      * Mark a review as approved by its ID.
      *
-     * @param int $reviewId
+     * @param int|null $reviewId
      * @return bool True if the update was successful, false if the review was not found.
      */
-    public function approveReview(int $reviewId = null): bool
+    public function approveReview(?int $reviewId = null): bool
     {
+        if ($reviewId === null) {
+            return false;
+        }
+
         $review = $this->reviews()->find($reviewId);
         if (!$review) {
             return false;
         }
+
         return $review->update(['approved' => true]);
     }
 
     /**
      * Calculate the average rating for a given key, filtering reviews by approval.
      *
-     * @param string $key
-     * @param bool $approved
+     * @param string|null $key
+     * @param bool        $approved
      * @return float|null
      */
-    public function averageRating(string $key = null, bool $approved = true): ?float
+    public function averageRating(?string $key = null, bool $approved = true): ?float
     {
         return $this->reviews()
             ->where('approved', $approved)
-            ->whereHas('ratings', function ($query) use ($key) {
-                $query->where('key', $key);
-            })
+            ->whereHas(
+                'ratings', function ($query) use ($key) {
+                    $query->where('key', $key);
+                }
+            )
             ->with('ratings')
             ->get()
             ->pluck('ratings')
@@ -204,15 +215,17 @@ trait ReviewRateable
             ->where('approved', $approved)
             ->with('ratings')
             ->get()
-            ->each(function ($review) use (&$averages) {
-                foreach ($review->ratings as $rating) {
-                    if (!isset($averages[$rating->key])) {
-                        $averages[$rating->key] = ['sum' => 0, 'count' => 0];
+            ->each(
+                function ($review) use (&$averages) {
+                    foreach ($review->ratings as $rating) {
+                        if (!isset($averages[$rating->key])) {
+                            $averages[$rating->key] = ['sum' => 0, 'count' => 0];
+                        }
+                        $averages[$rating->key]['sum'] += $rating->value;
+                        $averages[$rating->key]['count']++;
                     }
-                    $averages[$rating->key]['sum'] += $rating->value;
-                    $averages[$rating->key]['count']++;
                 }
-            });
+            );
 
         foreach ($averages as $key => $data) {
             $averages[$key] = $data['count'] ? $data['sum'] / $data['count'] : null;
@@ -225,19 +238,24 @@ trait ReviewRateable
      * Calculate the average rating for a given key within a department,
      * filtering reviews by approval.
      *
-     * @param string $department
-     * @param string $key
-     * @param bool $approved
+     * @param string      $department
+     * @param string|null $key
+     * @param bool        $approved
      * @return float|null
      */
-    public function averageRatingByDepartment(string $department = "default", string $key = null, bool $approved = true): ?float
-    {
+    public function averageRatingByDepartment(
+        string $department = 'default',
+        ?string $key = null,
+        bool $approved = true
+    ): ?float {
         return $this->reviews()
             ->where('department', $department)
             ->where('approved', $approved)
-            ->whereHas('ratings', function ($query) use ($key) {
-                $query->where('key', $key);
-            })
+            ->whereHas(
+                'ratings', function ($query) use ($key) {
+                    $query->where('key', $key);
+                }
+            )
             ->with('ratings')
             ->get()
             ->pluck('ratings')
@@ -251,10 +269,10 @@ trait ReviewRateable
      * filtering reviews by approval.
      *
      * @param string $department
-     * @param bool $approved
+     * @param bool   $approved
      * @return array  Format: ['overall' => 4.5, 'quality' => 4.0, ...]
      */
-    public function averageRatingsByDepartment(string $department = "default", bool $approved = true): array
+    public function averageRatingsByDepartment(string $department = 'default', bool $approved = true): array
     {
         $averages = [];
 
@@ -263,15 +281,17 @@ trait ReviewRateable
             ->where('approved', $approved)
             ->with('ratings')
             ->get()
-            ->each(function ($review) use (&$averages) {
-                foreach ($review->ratings as $rating) {
-                    if (!isset($averages[$rating->key])) {
-                        $averages[$rating->key] = ['sum' => 0, 'count' => 0];
+            ->each(
+                function ($review) use (&$averages) {
+                    foreach ($review->ratings as $rating) {
+                        if (!isset($averages[$rating->key])) {
+                            $averages[$rating->key] = ['sum' => 0, 'count' => 0];
+                        }
+                        $averages[$rating->key]['sum'] += $rating->value;
+                        $averages[$rating->key]['count']++;
                     }
-                    $averages[$rating->key]['sum'] += $rating->value;
-                    $averages[$rating->key]['count']++;
                 }
-            });
+            );
 
         foreach ($averages as $key => $data) {
             $averages[$key] = $data['count'] ? $data['sum'] / $data['count'] : null;
@@ -304,12 +324,15 @@ trait ReviewRateable
      * filtered by the approved status.
      *
      * @param string $department
-     * @param bool $approved
-     * @param bool $withRatings
+     * @param bool   $approved
+     * @param bool   $withRatings
      * @return Collection
      */
-    public function getReviewsByDepartment(string $department = "default", bool $approved = true, bool $withRatings = true): Collection
-    {
+    public function getReviewsByDepartment(
+        string $department = 'default',
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection {
         $query = $this->reviews()
             ->where('department', $department)
             ->where('approved', $approved);
@@ -336,10 +359,10 @@ trait ReviewRateable
      * Get the total number of reviews for the model by department.
      *
      * @param string $department
-     * @param bool $approved
+     * @param bool   $approved
      * @return int
      */
-    public function totalDepartmentReviews(string $department = "default", bool $approved = true): int
+    public function totalDepartmentReviews(string $department = 'default', bool $approved = true): int
     {
         return $this->reviews()
             ->where('department', $department)
@@ -368,11 +391,15 @@ trait ReviewRateable
     /**
      * Delete a review by its ID.
      *
-     * @param int $reviewId
+     * @param int|null $reviewId
      * @return bool True if the review was deleted, false otherwise.
      */
-    public function deleteReview(int $reviewId = null): bool
+    public function deleteReview(?int $reviewId = null): bool
     {
+        if ($reviewId === null) {
+            return false;
+        }
+
         $review = $this->reviews()->find($reviewId);
 
         if ($review) {
@@ -386,22 +413,22 @@ trait ReviewRateable
      * Return an array of rating value ⇒ count, for the full model
      * or for a given department.
      *
-     * @param  string|null  $department  If null, counts across all departments.
-     * @param  bool         $approved    Only count approved reviews?
+     * @param  string|null $department  If null, counts across all departments.
+     * @param  bool        $approved    Only count approved reviews?
      * @return array        [1 => 12, 2 => 5, 3 => 23, 4 => 17, 5 => 42]
      */
-    public function ratingCounts(?string $department = "default", bool $approved = true): array
+    public function ratingCounts(?string $department = 'default', bool $approved = true): array
     {
         $min         = config('review-rateable.min_rating_value', 1);
         $max         = config('review-rateable.max_rating_value', 5);
-        $reviewTable = (new Review)->getTable();
-        $ratingTable = (new Rating)->getTable();
+        $reviewTable = (new Review())->getTable();
+        $ratingTable = (new Rating())->getTable();
 
         $query = Rating::select("{$ratingTable}.value", DB::raw('COUNT(*) as total'))
             ->join($reviewTable, "{$ratingTable}.review_id", '=', "{$reviewTable}.id")
             ->where("{$reviewTable}.reviewable_type", $this->getMorphClass())
-            ->where("{$reviewTable}.reviewable_id",   $this->getKey())
-            ->where("{$reviewTable}.approved",        $approved);
+            ->where("{$reviewTable}.reviewable_id", $this->getKey())
+            ->where("{$reviewTable}.approved", $approved);
 
         if ($department) {
             $query->where("{$reviewTable}.department", $department);
@@ -427,23 +454,23 @@ trait ReviewRateable
      *  • percentages: [1 => pct1, …, 5 => pct5]
      *  • total: total number of ratings
      *
-     * @param  string|null  $department
-     * @param  bool         $approved
+     * @param  string|null $department
+     * @param  bool        $approved
      * @return array
      */
-    public function ratingStats(?string $department = "default", bool $approved = true): array
+    public function ratingStats(?string $department = 'default', bool $approved = true): array
     {
         $min         = config('review-rateable.min_rating_value', 1);
         $max         = config('review-rateable.max_rating_value', 5);
-        $reviewTable = (new Review)->getTable();
-        $ratingTable = (new Rating)->getTable();
+        $reviewTable = (new Review())->getTable();
+        $ratingTable = (new Rating())->getTable();
 
         // base query: gives you value => count
         $raw = Rating::select("{$ratingTable}.value", DB::raw('COUNT(*) as count'))
             ->join($reviewTable, "{$ratingTable}.review_id", '=', "{$reviewTable}.id")
             ->where("{$reviewTable}.reviewable_type", $this->getMorphClass())
-            ->where("{$reviewTable}.reviewable_id",   $this->getKey())
-            ->where("{$reviewTable}.approved",        $approved)
+            ->where("{$reviewTable}.reviewable_id", $this->getKey())
+            ->where("{$reviewTable}.approved", $approved)
             ->when($department, fn($q) => $q->where("{$reviewTable}.department", $department))
             ->groupBy("{$ratingTable}.value")
             ->pluck('count', 'value')
@@ -476,19 +503,24 @@ trait ReviewRateable
     /**
      * Return reviews based on star ratings.
      *
-     * @param int $starValue
-     * @param string|null $department
+     * @param int|null $starValue
+     * @param string $department
      * @param bool $approved
      * @param bool $withRatings
+     *
      * @return Collection
      */
-    public function getReviewsByRating(int $starValue = null, string $department = "default", bool $approved = true, bool $withRatings = true): Collection
-    {
+    public function getReviewsByRating(
+        ?int $starValue = null,
+        string $department = 'default',
+        bool $approved = true,
+        bool $withRatings = true
+    ): Collection {
         $query = $this->reviews()
             ->when($approved, fn($q) => $q->where('approved', $approved))
             ->when($department, fn($q) => $q->where('department', $department))
-            ->whereHas('ratings', fn($q) =>
-            $q->where('value', $starValue)
+            ->whereHas(
+                'ratings', fn($q) => $q->where('value', $starValue)
             );
 
         if ($withRatings) {

--- a/tests/ReviewRateableTest.php
+++ b/tests/ReviewRateableTest.php
@@ -3,7 +3,9 @@
 namespace Codebyray\ReviewRateable\Tests;
 
 use Codebyray\ReviewRateable\Models\Review;
+use Codebyray\ReviewRateable\Services\ReviewRateableService;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Codebyray\ReviewRateable\Traits\ReviewRateable;
@@ -296,4 +298,90 @@ it('deletes a review successfully', function () use ($dummyModel) {
     // Delete the review by its ID.
     $deleted = $dummyInstance->deleteReview($review->id);
     expect($deleted)->toBeTrue();
+});
+
+it('returns false when updateReview is called without arguments', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Null Update']);
+
+    $result = $instance->updateReview();
+    expect($result)->toBeFalse();
+});
+
+it('returns false when approveReview is called without an id', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Null Approve']);
+
+    $result = $instance->approveReview();
+    expect($result)->toBeFalse();
+});
+
+it('returns false when deleteReview is called without an id', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Null Delete']);
+
+    $result = $instance->deleteReview();
+    expect($result)->toBeFalse();
+});
+
+it('handles getReviewsByRating called with no star value gracefully', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Null Star']);
+
+    $instance->addReview(
+        [
+            'review'   => 'Some review',
+            'approved' => true,
+            'ratings'  => ['overall' => 5],
+        ]
+    );
+
+    $reviews = $instance->getReviewsByRating();
+    expect($reviews)->toBeInstanceOf(Collection::class);
+});
+
+it('service addReview delegates to model', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Service Add']);
+    $service  = new ReviewRateableService();
+    $service->setModel($instance);
+
+    $review = $service->addReview(
+        [
+            'review'   => 'Via service',
+            'approved' => true,
+            'ratings'  => ['overall' => 5],
+        ], 1);
+
+    expect($review)->toBeInstanceOf(Review::class)
+        ->and($instance->reviews()->count())->toBe(1);
+});
+
+it('service updateReview delegates with id and data', function () use ($dummyModel) {
+    $instance = $dummyModel::create(['name' => 'Service Update']);
+    $service  = new ReviewRateableService();
+    $service->setModel($instance);
+
+    $review = $instance->addReview(
+        [
+            'review'   => 'Original',
+            'approved' => true,
+            'ratings'  => ['overall' => 5],
+        ]
+    );
+
+    $result = $service->updateReview($review->id, [
+        'review'  => 'Updated via service',
+        'ratings' => ['overall' => 3],
+    ]);
+
+    expect($result)->toBeTrue();
+
+    $fresh = $instance->reviews()->find($review->id);
+    expect($fresh->review)->toEqual('Updated via service')
+        ->and($fresh->ratings()->first()->value)->toEqual(3);
+});
+
+it('throws when using service without setting model', function () {
+    $service = new ReviewRateableService();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('No model set in ReviewRateableService');
+
+    $service->getReviews();
 });


### PR DESCRIPTION
Patch release addressing PHP 8.4 deprecation notices by making nullable parameters explicit. Fully backward compatible with 8.1–8.3. Adds coverage tests for null argument behavior and service delegation.